### PR TITLE
Fix: add missing hidden imports to PyInstaller build

### DIFF
--- a/.github/workflows/build-executables.yml
+++ b/.github/workflows/build-executables.yml
@@ -40,6 +40,10 @@ jobs:
           --paths . \
           --hidden-import utils \
           --hidden-import voter_data_automation \
+          --hidden-import voter_data_downloader \
+          --hidden-import van_file_manager \
+          --hidden-import auth \
+          --hidden-import printing_steps \
           --collect-submodules selenium \
           --add-data "macrovan_config.json:." \
           macrovat.py


### PR DESCRIPTION
Adds hidden-import flags for voter_data_downloader, van_file_manager, auth, and printing_steps to fix ModuleNotFoundError at runtime.